### PR TITLE
Update XSpec download URL and Saxon HE version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,9 @@
     </developers>
 
     <properties>
-        <xspec.groupId>com.google.code.xspec</xspec.groupId>
+        <xspec.groupId>com.github.expath.xspec</xspec.groupId>
         <xspec.artifactId>xspec</xspec.artifactId>
-        <xspec.version>0.4.0rc1</xspec.version>
+        <xspec.version>70cfe35e472be894236e09582e4fd06e032a3d4e</xspec.version>
         <xspec.packaging>zip</xspec.packaging>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.plugin-plugin.version>3.4</maven.plugin-plugin.version>
@@ -182,7 +182,7 @@
                             <artifactId>${xspec.artifactId}</artifactId>
                             <version>${xspec.version}</version>
                             <packaging>${xspec.packaging}</packaging>
-                            <downloadUrl>http://{artifactId}.googlecode.com/files/{artifactId}-{version}.{packaging}</downloadUrl>
+                            <downloadUrl>https://codeload.github.com/expath/xspec/zip/${xspec.version}</downloadUrl>
                         </artifactItem>
                     </artifactItems>
                 </configuration>
@@ -240,11 +240,10 @@
                         <configuration>
                             <target>
                                 <copy todir="${project.build.directory}/classes/xspec" verbose="true">
-                                    <fileset dir="${project.build.directory}/dependency/${xspec.artifactId}-${xspec.version}/src" includes="compiler/**" />
-                                    <fileset dir="${project.build.directory}/dependency/${xspec.artifactId}-${xspec.version}/src" includes="reporter/**" />
-                                    <filelist dir="${project.build.directory}/dependency/${xspec.artifactId}-${xspec.version}">
+                                    <fileset dir="${project.build.directory}/dependency/xspec-${xspec.version}/src" includes="compiler/**" />
+                                    <fileset dir="${project.build.directory}/dependency/xspec-${xspec.version}/src" includes="reporter/**" />
+                                    <filelist dir="${project.build.directory}/dependency/xspec-${xspec.version}">
                                         <file name="README" />
-                                        <file name="VERSION" />
                                     </filelist>
                                 </copy>
                             </target>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>net.sf.saxon</groupId>
             <artifactId>Saxon-HE</artifactId>
-            <version>9.7.0-1</version>
+            <version>9.7.0-14</version>
         </dependency>
 
         <!-- dependency>


### PR DESCRIPTION
XSpec is not available from Google Code anymore. I saw that you discussed this in the other active pull request. The commit I use is the one you linked to in one of your comments.

I updated Saxon HE to version 9.7.0-14 because I had problems with the plugin when I built with version 9.7.0-1. The first test worked fine, but the plugin seemed to use the XSLT from the first test for all later tests, even if there was a different XSLT file specified. Upgrading to 9.7.0-14 seems to fix this.

Update: Fixed already in version 9.7.0-2. This issue might be related: https://saxonica.plan.io/issues/2530